### PR TITLE
enable hot module reloading

### DIFF
--- a/client/components/ShoppingList.jsx
+++ b/client/components/ShoppingList.jsx
@@ -28,7 +28,6 @@ class ShoppingList extends React.Component {
 
   componentDidMount() {
     this.loadShoppingList();
-    this.testCall();
   }
 
   sortItems(array){
@@ -165,19 +164,6 @@ class ShoppingList extends React.Component {
     .then(data => {
       this.setState({editProduct: {}});
     })
-    .catch(err => console.log(err));
-  }
-
-  testCall() {
-    axios.get('/api/products', {
-      params: {
-        id: 'B073WV3KCD'
-      },
-      headers: {
-        Authorization: 'Bearer 5255b....c466'
-      }
-    })
-    .then(res => console.log(res.data))
     .catch(err => console.log(err));
   }
 

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -1,5 +1,24 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from '../components/App.jsx';
+import { AppContainer } from 'react-hot-loader';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+if (module.hot && HOT) {
+  const render = Component => {
+    ReactDOM.render(
+      <AppContainer>
+        <Component />
+      </AppContainer>,
+      document.getElementById('root')
+    )
+  }
+
+  render(App);
+
+  module.hot.accept('../components/App.jsx', () => {
+    const NextApp = require('../components/App.jsx').default;
+    render(NextApp);
+  })
+} else {
+  ReactDOM.render(<App/>, document.getElementById('root'));
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -323,22 +323,6 @@
         "@types/mime": "2.0.0"
       }
     },
-    "Base64": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
-      "integrity": "sha1-ujpCMHCOGGcFBl5mur3Uw1z2ACg=",
-      "dev": true
-    },
-    "JSONStream": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
-      "integrity": "sha1-kWV9/m/4V0gwZhMrRhi2Lo9Ih70=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "0.0.5",
-        "through": "2.3.8"
-      }
-    },
     "abab": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -1636,6 +1620,12 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "Base64": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
+      "integrity": "sha1-ujpCMHCOGGcFBl5mur3Uw1z2ACg=",
+      "dev": true
+    },
     "base64-js": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.7.tgz",
@@ -1833,10 +1823,10 @@
       "integrity": "sha1-+qHLxBSHsazEdH43PhFIrf/Q4tk=",
       "dev": true,
       "requires": {
-        "JSONStream": "0.8.4",
         "combine-source-map": "0.3.0",
         "concat-stream": "1.4.10",
         "defined": "0.0.0",
+        "JSONStream": "0.8.4",
         "through2": "0.5.1",
         "umd": "2.1.0"
       },
@@ -1937,7 +1927,6 @@
       "integrity": "sha1-V7XRlcxWgTnpcTAuXNnVjdr7VNg=",
       "dev": true,
       "requires": {
-        "JSONStream": "0.8.4",
         "assert": "1.1.2",
         "browser-pack": "3.2.0",
         "browser-resolve": "1.11.2",
@@ -1961,6 +1950,7 @@
         "inherits": "2.0.3",
         "insert-module-globals": "6.6.3",
         "isarray": "0.0.1",
+        "JSONStream": "0.8.4",
         "labeled-stream-splicer": "1.0.2",
         "module-deps": "3.9.1",
         "os-browserify": "0.1.2",
@@ -3293,16 +3283,6 @@
         "through2": "1.1.1"
       },
       "dependencies": {
-        "JSONStream": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-          "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-          "dev": true,
-          "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
-          }
-        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -3314,6 +3294,16 @@
           "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
           "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
           "dev": true
+        },
+        "JSONStream": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+          "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+          "dev": true,
+          "requires": {
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
+          }
         },
         "readable-stream": {
           "version": "1.1.14",
@@ -5668,6 +5658,13 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -5675,13 +5672,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -6784,6 +6774,14 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -6792,14 +6790,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
           }
         },
         "stringstream": {
@@ -7287,6 +7277,14 @@
         "readable-stream": "2.3.3"
       }
     },
+    "http_ece": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-0.5.2.tgz",
+      "integrity": "sha1-VlTX7J2Za3Sc4AonbhjVS22PkF8=",
+      "requires": {
+        "urlsafe-base64": "1.0.0"
+      }
+    },
     "http-browserify": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
@@ -7320,14 +7318,6 @@
         "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
         "sshpk": "1.13.1"
-      }
-    },
-    "http_ece": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-0.5.2.tgz",
-      "integrity": "sha1-VlTX7J2Za3Sc4AonbhjVS22PkF8=",
-      "requires": {
-        "urlsafe-base64": "1.0.0"
       }
     },
     "https-browserify": {
@@ -7519,26 +7509,16 @@
       "integrity": "sha1-IGOOKaMPntHKLjqCX7wsulJG3fw=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.1",
         "combine-source-map": "0.6.1",
         "concat-stream": "1.4.10",
         "is-buffer": "1.1.6",
+        "JSONStream": "1.3.1",
         "lexical-scope": "1.2.0",
         "process": "0.11.10",
         "through2": "1.1.1",
         "xtend": "4.0.1"
       },
       "dependencies": {
-        "JSONStream": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-          "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-          "dev": true,
-          "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
-          }
-        },
         "combine-source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
@@ -7588,6 +7568,16 @@
           "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
           "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
           "dev": true
+        },
+        "JSONStream": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+          "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+          "dev": true,
+          "requires": {
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
+          }
         },
         "lodash.memoize": {
           "version": "3.0.4",
@@ -8834,6 +8824,16 @@
       "integrity": "sha1-MwVCrT8KZUZlt3jz6y2an6UHrGQ=",
       "dev": true
     },
+    "JSONStream": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+      "integrity": "sha1-kWV9/m/4V0gwZhMrRhi2Lo9Ih70=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "0.0.5",
+        "through": "2.3.8"
+      }
+    },
     "jsonwebtoken": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.4.3.tgz",
@@ -9503,13 +9503,13 @@
       "integrity": "sha1-6nXK+RmQkNJbDVUStaysuW5/h/M=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.1",
         "browser-resolve": "1.11.2",
         "concat-stream": "1.4.10",
         "defined": "1.0.0",
         "detective": "4.6.0",
         "duplexer2": "0.0.2",
         "inherits": "2.0.3",
+        "JSONStream": "1.3.1",
         "parents": "1.0.1",
         "readable-stream": "1.1.14",
         "resolve": "1.5.0",
@@ -9519,16 +9519,6 @@
         "xtend": "4.0.1"
       },
       "dependencies": {
-        "JSONStream": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-          "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-          "dev": true,
-          "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
-          }
-        },
         "concat-stream": {
           "version": "1.4.10",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
@@ -9551,6 +9541,16 @@
           "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
           "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
           "dev": true
+        },
+        "JSONStream": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+          "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+          "dev": true,
+          "requires": {
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
+          }
         },
         "parents": {
           "version": "1.0.1",
@@ -9985,7 +9985,6 @@
       "resolved": "https://registry.npmjs.org/npm/-/npm-5.5.1.tgz",
       "integrity": "sha512-M3aO8EjHebaCw6uur4C86SZqkypnoaEVo5R63FEEU0dw9wLxf/JlwWtJItShYVyQS2WDxG2It10GEe5GmVEM2Q==",
       "requires": {
-        "JSONStream": "1.3.1",
         "abbrev": "1.1.1",
         "ansi-regex": "3.0.0",
         "ansicolors": "0.3.2",
@@ -10017,6 +10016,7 @@
         "ini": "1.3.4",
         "init-package-json": "1.10.1",
         "is-cidr": "1.0.0",
+        "JSONStream": "1.3.1",
         "lazy-property": "1.0.0",
         "libnpx": "9.6.0",
         "lockfile": "1.0.3",
@@ -10091,27 +10091,6 @@
         "write-file-atomic": "2.1.0"
       },
       "dependencies": {
-        "JSONStream": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-          "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-          "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
-          },
-          "dependencies": {
-            "jsonparse": {
-              "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-              "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
-            },
-            "through": {
-              "version": "2.3.8",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-              "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-            }
-          }
-        },
         "abbrev": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -10540,6 +10519,27 @@
               "version": "1.0.6",
               "resolved": "https://registry.npmjs.org/cidr-regex/-/cidr-regex-1.0.6.tgz",
               "integrity": "sha1-dKv9YZ3zcLnVSrFEdVaOl91kwME="
+            }
+          }
+        },
+        "JSONStream": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+          "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+          "requires": {
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
+          },
+          "dependencies": {
+            "jsonparse": {
+              "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+              "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
+            },
+            "through": {
+              "version": "2.3.8",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+              "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
             }
           }
         },
@@ -16379,6 +16379,14 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-format-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/string-format-obj/-/string-format-obj-1.1.0.tgz",
@@ -16419,14 +16427,6 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -518,6 +518,11 @@
       "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
       "dev": true
     },
+    "ansi-html": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
+      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -3457,6 +3462,11 @@
       "resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.0.2.tgz",
       "integrity": "sha1-7RfL9oq9EOCu+BgnE+KXxeS1ALA="
     },
+    "dom-walk": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
+    },
     "domain-browser": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
@@ -3697,6 +3707,14 @@
       "dev": true,
       "requires": {
         "is-arrayish": "0.2.1"
+      }
+    },
+    "error-stack-parser": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-1.3.6.tgz",
+      "integrity": "sha1-4Oc7k+QXE40c18C3RrGkoUhUwpI=",
+      "requires": {
+        "stackframe": "0.3.1"
       }
     },
     "es-abstract": {
@@ -5894,6 +5912,22 @@
         "is-glob": "2.0.1"
       }
     },
+    "global": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+      "requires": {
+        "min-document": "2.19.0",
+        "process": "0.5.2"
+      },
+      "dependencies": {
+        "process": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+          "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+        }
+      }
+    },
     "global-dirs": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
@@ -7162,6 +7196,11 @@
       "requires": {
         "whatwg-encoding": "1.0.3"
       }
+    },
+    "html-entities": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+      "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
     },
     "html-loader": {
       "version": "0.5.1",
@@ -9394,6 +9433,14 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
       "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
       "dev": true
+    },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "requires": {
+        "dom-walk": "0.1.1"
+      }
     },
     "minimalistic-assert": {
       "version": "1.0.0",
@@ -14913,8 +14960,7 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystring-es3": {
       "version": "0.2.1",
@@ -15053,6 +15099,11 @@
         "prop-types": "15.6.0"
       }
     },
+    "react-deep-force-update": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-deep-force-update/-/react-deep-force-update-2.1.1.tgz",
+      "integrity": "sha1-jqQmPNZFWgULN0RbPwj9g52G6Qk="
+    },
     "react-dom": {
       "version": "15.6.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
@@ -15064,6 +15115,25 @@
         "prop-types": "15.6.0"
       }
     },
+    "react-hot-loader": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-3.1.3.tgz",
+      "integrity": "sha512-d7nZf78irxoGN5PY4zd6CSgZiroOhvIWzRast3qwTn4sSnBwlt08kV8WMQ9mitmxEdlCTwZt+5ClrRSjxWguMQ==",
+      "requires": {
+        "global": "4.3.2",
+        "react-deep-force-update": "2.1.1",
+        "react-proxy": "3.0.0-alpha.1",
+        "redbox-react": "1.5.0",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
     "react-loading-overlay": {
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/react-loading-overlay/-/react-loading-overlay-0.2.8.tgz",
@@ -15072,6 +15142,14 @@
         "prop-types": "15.6.0",
         "react-transition-group": "1.2.1",
         "styled-components": "2.3.3"
+      }
+    },
+    "react-proxy": {
+      "version": "3.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-3.0.0-alpha.1.tgz",
+      "integrity": "sha1-RABCa8+oDKpnJMd1VpUxUgn6Swc=",
+      "requires": {
+        "lodash": "4.17.4"
       }
     },
     "react-router": {
@@ -15257,6 +15335,17 @@
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
           "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
         }
+      }
+    },
+    "redbox-react": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/redbox-react/-/redbox-react-1.5.0.tgz",
+      "integrity": "sha512-mdxArOI3sF8K5Nay5NG+lv/VW516TbXjjd4h1wcV1Iy4IMDQPnCayjoQXBAycAFSME4nyXRUXCjHxsw2rYpVRw==",
+      "requires": {
+        "error-stack-parser": "1.3.6",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.0",
+        "sourcemapped-stacktrace": "1.1.8"
       }
     },
     "reduce-css-calc": {
@@ -16009,6 +16098,21 @@
         "source-map": "0.5.7"
       }
     },
+    "sourcemapped-stacktrace": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/sourcemapped-stacktrace/-/sourcemapped-stacktrace-1.1.8.tgz",
+      "integrity": "sha512-OkVoI7GQOLl/laR1qsSo1c87tS8kF2VXhQq2SrQCDdXufBAcm8FgXogWso96ciMYoDtTw1Dn70CVdwYzoYs6Pg==",
+      "requires": {
+        "source-map": "0.5.6"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        }
+      }
+    },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
@@ -16076,6 +16180,11 @@
       "requires": {
         "safe-buffer": "5.1.1"
       }
+    },
+    "stackframe": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-0.3.1.tgz",
+      "integrity": "sha1-M6qE8Rd6VUjIk1Uzy/6zQgl19aQ="
     },
     "statuses": {
       "version": "1.4.0",
@@ -17516,6 +17625,17 @@
         "path-is-absolute": "1.0.1",
         "range-parser": "1.2.0",
         "time-stamp": "2.0.0"
+      }
+    },
+    "webpack-hot-middleware": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.21.0.tgz",
+      "integrity": "sha512-P6xiOLy10QlSVSO7GanU9PLxN6zLLQ7RG16MPTvmFwf2KUG7jMp6m+fmdgsR7xoaVVLA7OlX3YO6JjoZEKjCuA==",
+      "requires": {
+        "ansi-html": "0.0.7",
+        "html-entities": "1.2.1",
+        "querystring": "0.2.0",
+        "strip-ansi": "3.0.1"
       }
     },
     "webpack-merge": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node ./server/server.js",
     "server": "nodemon ./server/server.js",
+    "hot": "HOT=true nodemon ./server/server.js",
     "test": "NODE_ENV=test jest",
     "local-test": "NODE_ENV=test jest --watch",
     "windows-test": ".NODE_ENV=test& jest --watch --no-cache",
@@ -55,10 +56,12 @@
     "passport-oauth2-client-password": "^0.1.2",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
+    "react-hot-loader": "^3.1.3",
     "react-loading-overlay": "^0.2.8",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
     "web-push": "^3.2.5",
+    "webpack-hot-middleware": "^2.21.0",
     "xml2js": "^0.4.19"
   },
   "devDependencies": {

--- a/server/server.js
+++ b/server/server.js
@@ -15,15 +15,16 @@ const webpack = require('webpack');
 const webpackDevMiddleware = require('webpack-dev-middleware');
 const app = express();
 const axios = require('axios');
+const webpackHotMiddleware = require('webpack-hot-middleware');
 
 const path = require('path');
 const port = process.env.PORT || 3000;
-const isAuthenticated = require('./controllers/authroutes.js').isAuthenticated;
 
 /* helpers */
 const amazon = require('./helpers/amazon');
 const ebay = require('./helpers/ebay');
 /* controllers */
+const isAuthenticated = require('./controllers/authroutes.js').isAuthenticated;
 const shoppingList = require('./controllers/shoppingList');
 const userSettings = require('./controllers/userSettings');
 const { getLowestPrices, updateProduct, getPriceData } = require('./controllers/product');
@@ -48,10 +49,6 @@ let config;
 (port === 3000)? config = require('../webpack.dev.js') : config = require('../webpack.prod.js');
 const compiler = webpack(config);
 
-
-
-app.use(express.static(__dirname));
-
 app.use(passport.initialize());
 app.use(expressValidator())
 
@@ -60,6 +57,10 @@ const webpackDevMiddlewareInstance = webpackDevMiddleware( compiler, {
 });
 
 app.use(webpackDevMiddlewareInstance);
+
+if (process.env.HOT) {
+  app.use(webpackHotMiddleware(compiler));
+}
 
 const server = app.listen(port || 3000);
 console.log('server is listening on port ' + port);

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -4,9 +4,11 @@ const CleanWebpackPlugin = require('clean-webpack-plugin');
 const webpack = require('webpack');
 const ServiceWorkerWebpackPlugin = require('serviceworker-webpack-plugin');
 
+const entryApp = process.env.HOT ? ['react-hot-loader/patch', './client/src/index.jsx', 'webpack-hot-middleware/client'] : ['react-hot-loader/patch', './client/src/index.jsx'];
+
 module.exports = {
   entry: {
-    app: './client/src/index.jsx',
+    app: entryApp
   },
   module: {
     rules: [
@@ -85,6 +87,6 @@ module.exports = {
     new webpack.HotModuleReplacementPlugin(),
     new ServiceWorkerWebpackPlugin({
       entry: path.join(__dirname, './client/components/user/sw.js'),
-    }),
+    })
   ],
 }

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -84,7 +84,6 @@ module.exports = {
       title: 'Shopping',
       template: './index.html',
     }),
-    new webpack.HotModuleReplacementPlugin(),
     new ServiceWorkerWebpackPlugin({
       entry: path.join(__dirname, './client/components/user/sw.js'),
     })

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -4,6 +4,7 @@ const webpack = require('webpack');
 
 module.exports = merge(common, {
   plugins: [
+    new webpack.HotModuleReplacementPlugin(),
     new webpack.DefinePlugin({
      "HOT": process.env.HOT
     })

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,7 +1,13 @@
 const merge = require('webpack-merge');
 const common = require('./webpack.common.js');
+const webpack = require('webpack');
 
 module.exports = merge(common, {
+  plugins: [
+    new webpack.DefinePlugin({
+     "HOT": process.env.HOT
+    })
+  ],
   devtool: 'inline-source-map',
   devServer: {
     contentBase: './dist',


### PR DESCRIPTION
- run 'npm run hot' in terminal instead of 'npm run server' to use hot-reloading for react components

- 'npm run server' still runs nodemon normally without hot reloading

- the browser only reloads whatever module has been changed so it's faster than reloading the whole browser

- current app state should remain intact when hot reloading